### PR TITLE
Add FieldSupplierServiceState

### DIFF
--- a/src/main/java/com/wrmsr/search/dsl/field/FieldModule.java
+++ b/src/main/java/com/wrmsr/search/dsl/field/FieldModule.java
@@ -32,6 +32,7 @@ public class FieldModule
     @Override
     public void configure(Binder binder)
     {
+        binder.bind(FieldSupplierServiceState.class).in(SearchScoped.class);
         binder.bind(FieldSupplierService.class).to(FieldSupplierServiceImpl.class).in(SearchScoped.class);
         newSetBinder(binder, DocSpecific.class).addBinding().to(FieldSupplierServiceImpl.class).in(SearchScoped.class);
 

--- a/src/main/java/com/wrmsr/search/dsl/field/FieldSupplierServiceImpl.java
+++ b/src/main/java/com/wrmsr/search/dsl/field/FieldSupplierServiceImpl.java
@@ -13,6 +13,8 @@
  */
 package com.wrmsr.search.dsl.field;
 
+import javax.inject.Inject;
+
 import com.google.common.base.Throwables;
 import com.wrmsr.search.dsl.DocSpecific;
 import org.apache.lucene.document.Document;
@@ -24,30 +26,32 @@ import java.io.IOException;
 class FieldSupplierServiceImpl
         implements FieldSupplierService, DocSpecific
 {
-    private AtomicReaderContext atomicReaderContext;
-    private int docId;
 
-    public FieldSupplierServiceImpl()
+    private final FieldSupplierServiceState state;
+
+    @Inject
+    public FieldSupplierServiceImpl(FieldSupplierServiceState fieldSupplierServiceState)
     {
+        this.state = fieldSupplierServiceState;
     }
 
     @Override
     public void setAtomicReaderContext(AtomicReaderContext atomicReaderContext)
             throws IOException
     {
-        this.atomicReaderContext = atomicReaderContext;
+        state.atomicReaderContext = atomicReaderContext;
     }
 
     @Override
     public void setDocId(int docId)
     {
-        this.docId = docId;
+        state.docId = docId;
     }
 
     private Document getDocument()
     {
         try {
-            return atomicReaderContext.reader().document(docId);
+            return state.atomicReaderContext.reader().document(state.docId);
         }
         catch (IOException e) {
             throw Throwables.propagate(e);

--- a/src/main/java/com/wrmsr/search/dsl/field/FieldSupplierServiceState.java
+++ b/src/main/java/com/wrmsr/search/dsl/field/FieldSupplierServiceState.java
@@ -1,0 +1,8 @@
+package com.wrmsr.search.dsl.field;
+
+import org.apache.lucene.index.AtomicReaderContext;
+
+public class FieldSupplierServiceState {
+    public AtomicReaderContext atomicReaderContext;
+    public int docId;
+}


### PR DESCRIPTION
This fixes the failing unit test by sharing the state between the two FieldSupplierServiceImpl instances.
